### PR TITLE
Change amplification factor from 3^15 to 2^16.

### DIFF
--- a/scripts/onlinedbs/Rwcp.py
+++ b/scripts/onlinedbs/Rwcp.py
@@ -57,7 +57,7 @@ def importRirs(downloadDir, insertIntoDbF):
 
 		x, fs = sf.read(file, dtype='float32', **RawFormat)
 		x /= max(abs(x))
-		x = (3**15 * x).astype(np.int16)
+		x = (2**16 * x).astype(np.int16)
 
 		insertIntoDbF((x, fs), identifier, {
 			'source': 'RWCP',


### PR DESCRIPTION
The factor of 3^15 lead to clipping for a lot of the RIRs, since it did not fit 16bit.